### PR TITLE
Add link anchor to download section in release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Stand-alone desktop app used to view real-time video and gaze data from all Pupi
 ## Getting Started
 
 <a
-href="https://github.com/pupil-labs/pupil-invisible-monitor/releases/latest"
+href="https://github.com/pupil-labs/pupil-invisible-monitor/releases/latest#user-content-downloads"
 rel="noopener"
 target="_blank">
 	<p align="center">


### PR DESCRIPTION
So users are directed directly to the bottom of the release notes.