### PR TITLE
Clean up and fix requirements installation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The below steps are only required for software developers looking to work with t
 
 ### Install from source
 
+We recommend to setup a clean Python virtual environment for installing Pupil Invisible Monitor from source.
+
 ```sh
 git clone git@github.com:pupil-labs/pupil-invisible-monitor.git
 # Clone via HTTPS if you did not configure SSH correctly
@@ -55,37 +57,15 @@ cd pupil-invisible-monitor/
 
 # Use the Python 3 installation of your choice
 python -m pip install -U pip
-python -m pip install -r requirements.txt
+python -m pip install .
+
+# Or if you want to use an editable installation:
+python -m pip install -e .
 ```
-#### Linux Dependencies
-Pupil Invisible Monitor depends on GLFW-3.3 or above. Note that currently Ubuntu only offers packages for version 3.2, so you might need to install GLFW-3.3 [from source](https://github.com/glfw/glfw/releases/tag/3.3). Make sure to compile as a shared library! You might use the following snippet:
-```bash
-# install dependencies
-sudo apt install xorg-dev
-
-# download and unzip
-wget https://github.com/glfw/glfw/releases/download/3.3/glfw-3.3.zip
-unzip glfw-3.3.zip
-cd glfw-3.3
-
-# build and install as shared library
-cmake . -DBUILD_SHARED_LIBS=ON
-make -j4
-sudo make install
-
-# cleanup downloaded files
-cd ..
-rm glfw-3.3.zip
-rm -r glfw-3.3
-```
-
-#### Windows DLLs
-On Windows, additional steps are required:
-1. Follow the [Pupil download instructions for the GLFW dll](https://docs.pupil-labs.com/#glfw-to-pupil-external)
-1. Place the `glfw3.dll` file in the `windows_dlls` folder of this repository
-1. Add the `windows_dlls` folder path to your Windows environment variable `Path`
 
 ### Run as Python module
+
+After installating, Pupil Invisible Monitor is registered as a Python console script and can be executed from the command line via:
 
 ```sh
 # equivalent to running `python -m pupil_invisible_monitor`

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,9 +1,9 @@
 # Deployment
 
 ## Deployment dependencies
-Run the _Installation from source_ instructions but replace the last step with
+Run the _Install from source_ instructions, but install with the **deploy** option:
 ```sh
-python -m pip install -r requirements_deploy.txt
+python -m pip install ".[deploy]"
 ```
 
 ### Icon files

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
--r requirements_custom.txt
--e .

--- a/requirements_custom.txt
+++ b/requirements_custom.txt
@@ -1,3 +1,0 @@
--e git://github.com/pupil-labs/pyglui/@master#egg=pyglui
--e git://github.com/pupil-labs/pyndsi/@master#egg=ndsi
--e git://github.com/zeromq/pyre@master#egg=pyre

--- a/requirements_deploy.txt
+++ b/requirements_deploy.txt
@@ -1,2 +1,0 @@
--r requirements_custom.txt
--e .[deploy]

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,24 @@ from setuptools import setup
 
 from deployment._packaging.utils import get_version
 
+# Libs with Windows wheels need a fixed version to install the wheels automatically.
+PYLGUI_VERSION = "1.28"
+PYNDSI_VERSION = "1.3"
+
 requirements = [
-    "pyglui>=1.25",
-    "ndsi>=1.0.dev0",
     "numpy",
+    "glfw>=1.8.4",
     "PyOpenGL",
     "pyzmq",
-    "pyre",
-    "glfw>=1.8.4",
+    "pyre @ https://github.com/zeromq/pyre/archive/master.zip",
+    # Install pyglui from source for Unix and from wheel for Windows. Note we install
+    # via git, not from archive, as pyglui contains submodules which are not included in
+    # archive, but will be checked out when installing via git.
+    f'pyglui @ git+https://github.com/pupil-labs/pyglui.git@v{PYLGUI_VERSION} ; platform_system != "Windows"',
+    f'pyglui @ https://github.com/pupil-labs/pyglui/releases/download/v{PYLGUI_VERSION}/pyglui-{PYLGUI_VERSION}-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"',
+    # Install pyndsi from source for Unix and from wheel for Windows.
+    f'ndsi @ https://github.com/pupil-labs/pyndsi/archive/v{PYNDSI_VERSION}.zip ; platform_system != "Windows"',
+    f'ndsi @ https://github.com/pupil-labs/pyndsi/releases/download/v{PYNDSI_VERSION}/ndsi-{PYNDSI_VERSION}-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"',
 ]
 
 package = "pupil_invisible_monitor"


### PR DESCRIPTION
This PR intends to clean up the dependency setup with the multiple requirements.txt files and fixes missing dependencies for Windows. This is a result of the discussion in #21 

### Relevant Changes
- No more requirements.txt files
- No more manual installation of glfw binaries, as pyglfw now ships with them. That means no more dependencies to setup! :tada: 
- Correct automatic installation of source/wheel dependencies for Unix/Windows

### Additional Notes
Since [PEP508](https://www.python.org/dev/peps/pep-0508/) all the required options can be handled via `install_requires`:
- install from GitHub
- install wheel from custom URL
- install differently based on OS

@papr @romanroibu can one of you test if this works on macOS?
As in:
1. Make sure you **don't** have glfw installed in brew.
2. Create a clean virtualenv.
3. Just `pip install .` or `pip install -e .` from this repo.
4. Run `pupil_invisible_monitor`, make sure the app starts and you get an image from a PI.

- [X] ~~I'll leave this as a draft for now. If it works,~~ I'll adjust the related documentation as well in here and delete the requirements files.